### PR TITLE
fix: UI detection fails for fifth mask

### DIFF
--- a/Shaders/UIDetectMulti.fx
+++ b/Shaders/UIDetectMulti.fx
@@ -1230,8 +1230,8 @@ technique UIDetectMulti
 	#if (UIDM_MASK_COUNT > 4)
 		pass {
 			VertexShader = PostProcessVS;
-			PixelShader = PS_UIDetect4;
-			RenderTarget = texUIDetectMulti4;
+			PixelShader = PS_UIDetect5;
+			RenderTarget = texUIDetectMulti5;
 		}
 		pass {
 			VertexShader = PostProcessVS;


### PR DESCRIPTION
This is a simple bug fix for the fifth mask. Without this fix, the mask is always shown on `UIDM_MASK_COUNT=5`, whether the UI is detected or not.